### PR TITLE
Initialize go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module Smart-Music-Go
+
+go 1.23.8


### PR DESCRIPTION
## Summary
- initialize go module with `go mod init`

## Testing
- `go get github.com/zmb3/spotify golang.org/x/oauth2` *(fails: module download forbidden)*
- `go mod tidy` *(fails: module download forbidden)*
- `go test ./...` *(fails: no required module provides package github.com/zmb3/spotify)*

------
https://chatgpt.com/codex/tasks/task_e_683f62b48ea48321865754e2c8e2004e