### PR TITLE
Update imports for spotify and handlers packages

### DIFF
--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -3,7 +3,9 @@
 package handlers
 
 import (
+	"Smart-Music-Go/pkg/spotify"
 	"fmt"
+	"html/template"
 	"net/http"
 )
 
@@ -22,16 +24,16 @@ func (app *Application) Home(w http.ResponseWriter, r *http.Request) {
 	`)
 }
 
-/* In this function, we're getting the track query parameter from the request, 
-creating a new Spotify client, searching for the track, and printing the name of the first track found. 
+/* In this function, we're getting the track query parameter from the request,
+creating a new Spotify client, searching for the track, and printing the name of the first track found.
 You'll need to replace "your-client-id" and "your-client-secret" with your actual Spotify application's client ID and secret.
 
 This will display the name of the track, the name of the artist, and a link to listen to the track on Spotify.
 
-This is a very basic implementation and there's a lot more you can do. 
-For example, you could add pagination to display more search results, 
-add more details about the tracks, handle errors more gracefully, 
-add a login system to allow users to save their favorite tracks, and much more. 
+This is a very basic implementation and there's a lot more you can do.
+For example, you could add pagination to display more search results,
+add more details about the tracks, handle errors more gracefully,
+add a login system to allow users to save their favorite tracks, and much more.
 The possibilities are endless! */
 
 // Search is a handler function which will be used to handle search requests.

--- a/pkg/spotify/spotify.go
+++ b/pkg/spotify/spotify.go
@@ -1,9 +1,10 @@
-// This file will contain the code to interact with the Spotify API. 
+// This file will contain the code to interact with the Spotify API.
 
 package spotify
 
 import (
 	"context"
+	"fmt"
 	"github.com/zmb3/spotify"
 	"golang.org/x/oauth2/clientcredentials"
 )
@@ -31,7 +32,7 @@ func NewSpotifyClient(clientID string, clientSecret string) SpotifyClient {
 }
 
 // SearchTrack searches for a track on Spotify
-// This function performs a search on Spotify for the given track and returns the first result. 
+// This function performs a search on Spotify for the given track and returns the first result.
 // If no tracks are found, it returns an error.
 func (sc *SpotifyClient) SearchTrack(track string) (spotify.FullTrack, error) {
 	results, err := sc.Client.Search(track, spotify.SearchTypeTrack)
@@ -45,4 +46,3 @@ func (sc *SpotifyClient) SearchTrack(track string) (spotify.FullTrack, error) {
 
 	return spotify.FullTrack{}, fmt.Errorf("no tracks found")
 }
-


### PR DESCRIPTION
## Summary
- add missing `fmt` import for spotify client
- update handlers imports to include `html/template` and spotify package

## Testing
- `go vet ./...` *(fails: directory prefix does not contain main module)*
- `GO111MODULE=off go vet ./...` *(fails to find packages)*

------
https://chatgpt.com/codex/tasks/task_e_683f62b9404883218e96746757570dcf