### PR TITLE
Add tests for handlers and make spotify client injectable

### DIFF
--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -4,15 +4,18 @@ package main
 
 import (
 	"net/http"
+
 	"Smart-Music-Go/pkg/handlers"
+	"Smart-Music-Go/pkg/spotify"
 )
 
 func main() {
 	// Initialize a new http.ServeMux, which is basically a HTTP request router (or multiplexer)
 	mux := http.NewServeMux()
 
-	// Initialize a new instance of application which contains pointers to our two handler methods
-	app := &handlers.Application{}
+	// Initialize a Spotify client and application with dependencies
+	sc := spotify.NewSpotifyClient("your-client-id", "your-client-secret")
+	app := &handlers.Application{Spotify: sc}
 
 	// Register the two URL patterns and their corresponding handler functions to the router
 	mux.HandleFunc("/", app.Home)

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -10,8 +10,10 @@ import (
 	"Smart-Music-Go/pkg/spotify"
 )
 
-// Application struct to hold the methods for routes
-type Application struct{}
+// Application struct holds dependencies for HTTP handlers.
+type Application struct {
+	Spotify spotify.TrackSearcher
+}
 
 // Home is a simple handler function which writes a response.
 // This will display a form on the home page where users can enter a track name and click on the "Search" button to search for the track.
@@ -42,15 +44,11 @@ func (app *Application) Search(w http.ResponseWriter, r *http.Request) {
 	// Get the query parameter for the track from the URL
 	track := r.URL.Query().Get("track")
 
-	// Create a new Spotify client using the client ID and secret
-	// Replace "your-client-id" and "your-client-secret" with your actual client ID and secret
-	sc := spotify.NewSpotifyClient("your-client-id", "your-client-secret")
-
 	// Use the Spotify client to search for the track
 	// The SearchTrack function returns the first track found and an error
 	// If no tracks are found, the error will be "no tracks found"
 	// If an error occurs during the search, it will be a different error
-	result, err := sc.SearchTrack(track)
+	result, err := app.Spotify.SearchTrack(track)
 	if err != nil {
 		// If the error is "no tracks found", respond with a user-friendly message
 		if err.Error() == "no tracks found" {

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -1,0 +1,85 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	libspotify "github.com/zmb3/spotify"
+)
+
+type fakeSearcher struct {
+	track libspotify.FullTrack
+	err   error
+}
+
+func (f fakeSearcher) SearchTrack(track string) (libspotify.FullTrack, error) {
+	return f.track, f.err
+}
+
+func TestMain(m *testing.M) {
+	// change working directory to project root so template paths resolve
+	os.Chdir("../..")
+	os.Exit(m.Run())
+}
+
+func TestHome(t *testing.T) {
+	app := &Application{}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+
+	app.Home(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "Welcome to Smart-Music-Go!") {
+		t.Errorf("response missing welcome message")
+	}
+	if !strings.Contains(body, "<form") {
+		t.Errorf("response missing form")
+	}
+}
+
+func TestSearchFound(t *testing.T) {
+	track := libspotify.FullTrack{SimpleTrack: libspotify.SimpleTrack{
+		Name:         "Song",
+		Artists:      []libspotify.SimpleArtist{{Name: "Artist"}},
+		ExternalURLs: map[string]string{"spotify": "http://example.com"},
+	}}
+	app := &Application{Spotify: fakeSearcher{track: track}}
+
+	req := httptest.NewRequest(http.MethodGet, "/search?track=test", nil)
+	rr := httptest.NewRecorder()
+
+	app.Search(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "Search Results") ||
+		!strings.Contains(body, "Song") ||
+		!strings.Contains(body, "Artist") {
+		t.Errorf("unexpected body: %s", body)
+	}
+}
+
+func TestSearchNotFound(t *testing.T) {
+	app := &Application{Spotify: fakeSearcher{err: fmt.Errorf("no tracks found")}}
+	req := httptest.NewRequest(http.MethodGet, "/search?track=missing", nil)
+	rr := httptest.NewRecorder()
+
+	app.Search(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), "No tracks found for 'missing'") {
+		t.Errorf("unexpected response: %s", rr.Body.String())
+	}
+}

--- a/pkg/spotify/spotify.go
+++ b/pkg/spotify/spotify.go
@@ -15,8 +15,15 @@ type SpotifyClient struct {
 	Client spotify.Client
 }
 
+// TrackSearcher describes the ability to search for tracks.
+type TrackSearcher interface {
+	SearchTrack(track string) (spotify.FullTrack, error)
+}
+
+var _ TrackSearcher = (*SpotifyClient)(nil)
+
 // NewSpotifyClient creates a new Spotify API client with client credentials
-func NewSpotifyClient(clientID string, clientSecret string) SpotifyClient {
+func NewSpotifyClient(clientID string, clientSecret string) *SpotifyClient {
 	config := &clientcredentials.Config{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
@@ -29,7 +36,7 @@ func NewSpotifyClient(clientID string, clientSecret string) SpotifyClient {
 	}
 
 	client := spotify.Authenticator{}.NewClient(token)
-	return SpotifyClient{Client: client}
+	return &SpotifyClient{Client: client}
 }
 
 // SearchTrack searches for a track on Spotify

--- a/ui/templates/search_results.html
+++ b/ui/templates/search_results.html
@@ -1,4 +1,4 @@
 <h1>Search Results</h1>
 <h2>{{.Name}}</h2>
-<p>By: {{.Artists[0].Name}}</p>
+<p>By: {{(index .Artists 0).Name}}</p>
 <p><a href="{{.ExternalURLs.spotify}}">Listen on Spotify</a></p>


### PR DESCRIPTION
## Summary
- refactor handlers to accept a TrackSearcher dependency
- make spotify client constructor return a pointer and define TrackSearcher interface
- adjust main initialization for new app structure
- fix template syntax
- add unit tests for handlers

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`