### PR TITLE
Use env vars for Spotify credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+SPOTIFY_CLIENT_ID=your-client-id
+SPOTIFY_CLIENT_SECRET=your-client-secret

--- a/README.md
+++ b/README.md
@@ -14,8 +14,22 @@ The application allows users to search for music tracks. When a user enters a tr
 - go.mod and go.sum: These files are used by Go's module system.
 
 # Set-up
-Install a Go client for the Spotify Web API. One such client is zmb3/spotify. 
-You can install it by running go get github.com/zmb3/spotify in your terminal.
+Install a Go client for the Spotify Web API. One such client is zmb3/spotify.
+You can install it by running `go get github.com/zmb3/spotify` in your terminal.
+
+### Environment Variables
+The application requires Spotify credentials. Set the following variables before running:
+
+```
+SPOTIFY_CLIENT_ID=your-client-id
+SPOTIFY_CLIENT_SECRET=your-client-secret
+```
+
+You can copy the provided `.env.example` to `.env` and populate your values:
+
+```
+cp .env.example .env
+```
 
 
 # Future Work

--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -3,7 +3,9 @@
 package main
 
 import (
+	"log"
 	"net/http"
+	"os"
 
 	"Smart-Music-Go/pkg/handlers"
 	"Smart-Music-Go/pkg/spotify"
@@ -13,8 +15,15 @@ func main() {
 	// Initialize a new http.ServeMux, which is basically a HTTP request router (or multiplexer)
 	mux := http.NewServeMux()
 
+	// Load Spotify credentials from environment variables
+	clientID := os.Getenv("SPOTIFY_CLIENT_ID")
+	clientSecret := os.Getenv("SPOTIFY_CLIENT_SECRET")
+	if clientID == "" || clientSecret == "" {
+		log.Fatal("SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET must be set")
+	}
+
 	// Initialize a Spotify client and application with dependencies
-	sc := spotify.NewSpotifyClient("your-client-id", "your-client-secret")
+	sc := spotify.NewSpotifyClient(clientID, clientSecret)
 	app := &handlers.Application{Spotify: sc}
 
 	// Register the two URL patterns and their corresponding handler functions to the router


### PR DESCRIPTION
## Summary
- fetch Spotify credentials from the environment in `cmd/web/main.go`
- explain required variables in README and add `.env.example`

## Testing
- `go test ./...`