### PR TITLE
Add Spotify client tests and update workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: 1.23.8
 
     - name: Build
       run: go build -v ./...

--- a/pkg/spotify/spotify.go
+++ b/pkg/spotify/spotify.go
@@ -11,8 +11,13 @@ import (
 )
 
 // SpotifyClient is a wrapper around the Spotify API client
+type searcher interface {
+	Search(query string, t spotify.SearchType) (*spotify.SearchResult, error)
+}
+
+// SpotifyClient is a wrapper around the Spotify API client
 type SpotifyClient struct {
-	Client spotify.Client
+	client searcher
 }
 
 // TrackSearcher describes the ability to search for tracks.
@@ -35,15 +40,15 @@ func NewSpotifyClient(clientID string, clientSecret string) *SpotifyClient {
 		panic(err)
 	}
 
-	client := spotify.Authenticator{}.NewClient(token)
-	return &SpotifyClient{Client: client}
+	c := spotify.Authenticator{}.NewClient(token)
+	return &SpotifyClient{client: &c}
 }
 
 // SearchTrack searches for a track on Spotify
 // This function performs a search on Spotify for the given track and returns the first result.
 // If no tracks are found, it returns an error.
 func (sc *SpotifyClient) SearchTrack(track string) (spotify.FullTrack, error) {
-	results, err := sc.Client.Search(track, spotify.SearchTypeTrack)
+	results, err := sc.client.Search(track, spotify.SearchTypeTrack)
 	if err != nil {
 		return spotify.FullTrack{}, err
 	}

--- a/pkg/spotify/spotify_test.go
+++ b/pkg/spotify/spotify_test.go
@@ -1,0 +1,59 @@
+package spotify
+
+import (
+	"errors"
+	"testing"
+
+	libspotify "github.com/zmb3/spotify"
+)
+
+type fakeSearcher struct {
+	lastQuery string
+	lastType  libspotify.SearchType
+	result    *libspotify.SearchResult
+	err       error
+}
+
+func (f *fakeSearcher) Search(query string, t libspotify.SearchType) (*libspotify.SearchResult, error) {
+	f.lastQuery = query
+	f.lastType = t
+	return f.result, f.err
+}
+
+func TestSearchTrackFound(t *testing.T) {
+	track := libspotify.FullTrack{SimpleTrack: libspotify.SimpleTrack{Name: "Song"}}
+	sr := &libspotify.SearchResult{Tracks: &libspotify.FullTrackPage{Tracks: []libspotify.FullTrack{track}}}
+	fs := &fakeSearcher{result: sr}
+	sc := &SpotifyClient{client: fs}
+
+	got, err := sc.SearchTrack("q")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Name != "Song" {
+		t.Errorf("expected Song, got %s", got.Name)
+	}
+	if fs.lastQuery != "q" || fs.lastType != libspotify.SearchTypeTrack {
+		t.Errorf("Search called with %s %v", fs.lastQuery, fs.lastType)
+	}
+}
+
+func TestSearchTrackNotFound(t *testing.T) {
+	sr := &libspotify.SearchResult{Tracks: &libspotify.FullTrackPage{}}
+	sc := &SpotifyClient{client: &fakeSearcher{result: sr}}
+
+	_, err := sc.SearchTrack("missing")
+	if err == nil || err.Error() != "no tracks found" {
+		t.Fatalf("expected no tracks found error, got %v", err)
+	}
+}
+
+func TestSearchTrackError(t *testing.T) {
+	fs := &fakeSearcher{err: errors.New("boom")}
+	sc := &SpotifyClient{client: fs}
+
+	_, err := sc.SearchTrack("fail")
+	if err == nil || err.Error() != "boom" {
+		t.Fatalf("expected boom error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- abstract Spotify client search interface for easier testing
- unit test Spotify track searching logic
- update CI to use Go version from go.mod

## Testing
- `go test ./...`