### PR TITLE
Add favorites feature with DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ SPOTIFY_CLIENT_ID=your-client-id
 SPOTIFY_CLIENT_SECRET=your-client-secret
 ```
 
+Set `DATABASE_PATH` to the SQLite file (defaults to `smartmusic.db`):
+
+```
+DATABASE_PATH=smartmusic.db
+```
+The database schema is created automatically on startup, so no manual migrations are required.
+
 You can copy the provided `.env.example` to `.env` and populate your values:
 
 ```
@@ -47,6 +54,9 @@ go run cmd/web/main.go
 
 ### Viewing Results
 Visit `http://localhost:4000/login` to authorize with Spotify. After authorization, open `http://localhost:4000/playlists` or perform a search.
+
+### Favorites
+After logging in you can mark tracks as favorites from the search results. View them at `/favorites` or from the React "Favorites" tab.
 
 ### Frontend Setup
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module Smart-Music-Go
 go 1.23.8
 
 require (
+	github.com/mattn/go-sqlite3 v1.14.28
 	github.com/zmb3/spotify v1.3.0
 	golang.org/x/oauth2 v0.30.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/mattn/go-sqlite3 v1.14.28 h1:ThEiQrnbtumT+QMknw63Befp/ce/nUPgBPMlRFEum7A=
+github.com/mattn/go-sqlite3 v1.14.28/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -1,0 +1,28 @@
+package db
+
+import (
+	"os"
+	"testing"
+)
+
+func TestAddAndListFavorites(t *testing.T) {
+	d, err := New("test.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		d.Close()
+		os.Remove("test.db")
+	}()
+
+	if err := d.AddFavorite("u", "1", "Song", "Artist"); err != nil {
+		t.Fatal(err)
+	}
+	favs, err := d.ListFavorites("u")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(favs) != 1 || favs[0].TrackID != "1" {
+		t.Fatalf("unexpected favorites: %+v", favs)
+	}
+}

--- a/ui/frontend/src/App.jsx
+++ b/ui/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import Search from './Search.jsx'
 import Playlists from './Playlists.jsx'
+import Favorites from './Favorites.jsx'
 import './App.css'
 
 function App() {
@@ -12,8 +13,9 @@ function App() {
       <nav>
         <button onClick={() => setView('search')}>Search</button>
         <button onClick={() => setView('playlists')}>Playlists</button>
+        <button onClick={() => setView('favorites')}>Favorites</button>
       </nav>
-      {view === 'search' ? <Search /> : <Playlists />}
+      {view === 'search' ? <Search /> : view === 'playlists' ? <Playlists /> : <Favorites />}
     </div>
   )
 }

--- a/ui/frontend/src/Favorites.jsx
+++ b/ui/frontend/src/Favorites.jsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react'
+
+function Favorites() {
+  const [html, setHtml] = useState('')
+
+  useEffect(() => {
+    fetch('/favorites')
+      .then((res) => res.text())
+      .then((text) => setHtml(text))
+      .catch(() => setHtml('Failed to load favorites'))
+  }, [])
+
+  return (
+    <div>
+      <h2>Your Favorites</h2>
+      <div dangerouslySetInnerHTML={{ __html: html }} />
+    </div>
+  )
+}
+
+export default Favorites

--- a/ui/templates/favorites.html
+++ b/ui/templates/favorites.html
@@ -1,0 +1,8 @@
+<h1>Your Favorites</h1>
+<ul>
+{{range .}}
+  <li>{{.TrackName}} - {{.ArtistName}}</li>
+{{else}}
+  <li>No favorites saved</li>
+{{end}}
+</ul>

--- a/ui/templates/index.html
+++ b/ui/templates/index.html
@@ -21,9 +21,19 @@
             {{end}}
             <p class="name">{{.Name}}</p>
             <p class="artist">{{(index .Artists 0).Name}}</p>
+            <button onclick="addFav('{{.ID}}','{{.Name}}','{{(index .Artists 0).Name}}')">Favorite</button>
         </div>
         {{end}}
     </div>
     {{end}}
+<script>
+function addFav(id,name,artist){
+  fetch('/favorites',{
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({track_id:id,track_name:name,artist_name:artist})
+  });
+}
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- create SQLite storage layer for tokens and favorite tracks
- save OAuth token and user ID in DB on login
- provide `/favorites` endpoint for creating and listing favorite tracks
- add favorites UI pages and React component
- document `DATABASE_PATH` environment variable and favorites usage

## Testing
- `go mod tidy`
- `go build /tmp/test.go` *(fails: command hangs)*
- `go test ./...` *(fails: command hangs)*