### PR TITLE
Add integration and E2E tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,3 +26,16 @@ jobs:
 
     - name: Test
       run: go test -v ./...
+
+    - name: Set up Node
+      uses: actions/setup-node@v3
+      with:
+        node-version: 20
+
+    - name: Install frontend deps and run e2e tests
+      run: |
+        cd ui/frontend
+        npm ci
+        npm run build
+        npx playwright install --with-deps
+        npx playwright test

--- a/cmd/web/main_test.go
+++ b/cmd/web/main_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"Smart-Music-Go/pkg/db"
+	"Smart-Music-Go/pkg/handlers"
+	libspotify "github.com/zmb3/spotify"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+type fakeSearcher struct {
+	tracks []libspotify.FullTrack
+	err    error
+}
+
+func (f fakeSearcher) SearchTrack(track string) ([]libspotify.FullTrack, error) {
+	return f.tracks, f.err
+}
+
+func TestMain(m *testing.M) {
+	os.Chdir("../..")
+	os.Exit(m.Run())
+}
+
+func newServer() *httptest.Server {
+	fs := fakeSearcher{tracks: []libspotify.FullTrack{
+		{SimpleTrack: libspotify.SimpleTrack{Name: "Song", Artists: []libspotify.SimpleArtist{{Name: "Artist"}}, ExternalURLs: map[string]string{"spotify": "http://example.com"}}},
+	}}
+	auth := libspotify.NewAuthenticator("http://example.com/callback")
+	auth.SetAuthInfo("id", "secret")
+	database, _ := db.New(":memory:")
+	app := &handlers.Application{Spotify: fs, Authenticator: auth, DB: database}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", app.Home)
+	mux.HandleFunc("/search", app.Search)
+	mux.HandleFunc("/login", app.Login)
+	mux.HandleFunc("/callback", app.OAuthCallback)
+	mux.HandleFunc("/playlists", app.Playlists)
+	mux.HandleFunc("/favorites", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			app.AddFavorite(w, r)
+		} else {
+			app.Favorites(w, r)
+		}
+	})
+	mux.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.Dir("./ui/static"))))
+	mux.Handle("/app/", http.StripPrefix("/app/", http.FileServer(http.Dir("./ui/frontend/dist"))))
+	return httptest.NewServer(mux)
+}
+
+func TestSearchEndpoint(t *testing.T) {
+	srv := newServer()
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + "/search?track=test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 got %d", resp.StatusCode)
+	}
+	data, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(data), "Search Results") {
+		t.Errorf("unexpected body %s", data)
+	}
+}
+
+func TestLoginEndpoint(t *testing.T) {
+	srv := newServer()
+	defer srv.Close()
+	client := &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse }}
+	resp, err := client.Get(srv.URL + "/login")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected 302 got %d", resp.StatusCode)
+	}
+	loc := resp.Header.Get("Location")
+	if !strings.Contains(loc, "accounts.spotify.com") {
+		t.Errorf("unexpected redirect %s", loc)
+	}
+}
+
+func TestPlaylistsUnauthenticated(t *testing.T) {
+	srv := newServer()
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + "/playlists")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 got %d", resp.StatusCode)
+	}
+}

--- a/ui/frontend/package-lock.json
+++ b/ui/frontend/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
+        "@playwright/test": "^1.43.1",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^4.4.1",
@@ -1015,6 +1016,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
+      "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2389,6 +2406,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
+      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
+      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/ui/frontend/package.json
+++ b/ui/frontend/package.json
@@ -22,6 +22,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "@playwright/test": "^1.43.1"
   }
 }

--- a/ui/frontend/playwright.config.cjs
+++ b/ui/frontend/playwright.config.cjs
@@ -1,0 +1,14 @@
+// @ts-check
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+  webServer: {
+    command: 'npm run preview -- --port=4173',
+    port: 4173,
+    cwd: __dirname,
+    timeout: 120 * 1000,
+    reuseExistingServer: true,
+  },
+  use: { baseURL: 'http://localhost:4173' },
+});

--- a/ui/frontend/tests/basic.spec.cjs
+++ b/ui/frontend/tests/basic.spec.cjs
@@ -1,0 +1,6 @@
+const { test, expect } = require('@playwright/test');
+
+test('loads homepage', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('h1')).toHaveText('Smart Music Go');
+});


### PR DESCRIPTION
## Summary
- add HTTP integration tests under `cmd/web`
- add Playwright dependency with config and simple test
- run Node E2E tests in CI

## Testing
- `go test ./cmd/web -run TestSearchEndpoint -v`
- `go test ./cmd/web -run TestLoginEndpoint -v`
- `go test ./cmd/web -run TestPlaylistsUnauthenticated -v`
- `go test ./...`
- `npm run build` *(fails: vite not found or network)*
- `npx playwright install --with-deps` *(fails: domain forbidden)*
- `npx playwright test` *(fails: browser not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844a348d73c8321933c461599e84c7e