### PR TITLE
Add release Docker build

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,6 +8,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  release:
+    types: [ published ]
 
 jobs:
 
@@ -39,3 +41,28 @@ jobs:
         npm run build
         npx playwright install --with-deps
         npx playwright test
+
+  docker:
+    if: github.event_name == 'release'
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Log in to registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+      - name: Trigger deployment
+        if: secrets.DEPLOY_WEBHOOK != ''
+        run: curl -X POST ${{ secrets.DEPLOY_WEBHOOK }}


### PR DESCRIPTION
## Summary
- build Docker image on GitHub release and push to a registry
- optionally hit a deployment webhook after publish

## Testing
- `go test ./...`
- `npm run build` *(frontend)*
- `npx playwright install --with-deps` *(fails: download blocked)*
- `npx playwright test` *(fails: browser executable missing)*