### PR TITLE
Add docs for usage, deployment and contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing
+
+Thank you for considering contributing to Smart-Music-Go! The following guidelines help keep the project consistent and easy to work with.
+
+## Development Setup
+1. Install Go 1.23 or later and clone the repository.
+2. Copy `.env.example` to `.env` and provide your Spotify credentials as described in [docs/usage.md](docs/usage.md).
+3. Build the frontend assets under `ui/frontend` with `npm install && npm run build`.
+
+## Coding Standards
+- Run `gofmt -w` on all Go files before committing.
+- Ensure tests pass with:
+  ```bash
+  go test ./...
+  ```
+- For frontend changes run `npm run build` so that `ui/frontend/dist` is updated.
+
+## Pull Requests
+1. Create a feature branch for your change.
+2. Commit your work with clear messages.
+3. Open a pull request describing the motivation and any relevant issue numbers.
+
+We welcome bug fixes, new features and documentation improvements!

--- a/README.md
+++ b/README.md
@@ -114,8 +114,17 @@ AWS Secrets Manager or Heroku config vars). When running via Docker Compose or
 Terraform, the variables from `.env` can be supplied via `env_file` or the
 Terraform variables.
 
+
 For SSL, terminate TLS at your load balancer or reverse proxy using a certificate
 from Let's Encrypt or your cloud provider's certificate manager.
+
+## Documentation
+Detailed guides for running the application, deploying to production and
+contributing can be found in the [docs](docs) directory:
+
+- [Usage](docs/usage.md) – running locally and configuring authentication
+- [Deployment](docs/deployment.md) – production deployment options
+- [Contributing](CONTRIBUTING.md)
 
 
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,31 @@
+# Deployment
+
+This document describes options for deploying Smart-Music-Go in a production environment.
+
+## Build and Push the Docker Image
+1. Build the image locally:
+   ```bash
+   docker build -t smart-music-go .
+   ```
+2. Tag and push to your registry:
+   ```bash
+   docker tag smart-music-go <registry>/smart-music-go
+   docker push <registry>/smart-music-go
+   ```
+
+## Running the Container
+Run the image on your platform of choice, passing the environment variables used in development (`SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`, `SPOTIFY_REDIRECT_URL`, and `DATABASE_PATH`). When using Docker Compose you can supply an `.env` file.
+
+## AWS Fargate Example
+Example Terraform for deploying to AWS Fargate is provided under `deploy/aws`. After pushing your image:
+```bash
+cd deploy/aws
+terraform init
+terraform apply
+```
+Fill in the required variables in `terraform.tfvars` (an example file is included) such as the VPC, subnets, ACM certificate and the Spotify credentials.
+
+The output `load_balancer_dns` contains the HTTPS address for the service.
+
+## Production Configuration
+Store secrets using your cloud provider's secret management solution (for example AWS Secrets Manager or Heroku config vars). If you terminate TLS at a load balancer or reverse proxy, ensure that `SPOTIFY_REDIRECT_URL` matches the public HTTPS URL of `/callback`.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,49 @@
+# Usage
+
+This guide covers running Smart-Music-Go locally and configuring Spotify authentication.
+
+## Prerequisites
+- Go 1.23 or later
+- `go install github.com/zmb3/spotify@latest`
+- Node.js and npm for building the React frontend
+
+## Configuration
+1. Copy `.env.example` to `.env` and fill in your Spotify credentials:
+   ```bash
+   cp .env.example .env
+   ```
+2. Edit `.env` and set:
+   ```
+   SPOTIFY_CLIENT_ID=<your-client-id>
+   SPOTIFY_CLIENT_SECRET=<your-client-secret>
+   SPOTIFY_REDIRECT_URL=http://localhost:4000/callback
+   ```
+   Optionally set `DATABASE_PATH` to control where the SQLite database is stored (defaults to `smartmusic.db`).
+3. In your Spotify developer dashboard add `http://localhost:4000/callback` as an allowed redirect URI.
+
+## Building the Frontend
+```
+cd ui/frontend
+npm install
+npm run build
+```
+The built assets will be served from `/app/` when the Go server runs.
+
+## Running the Server
+Start the application with:
+```bash
+go run cmd/web/main.go
+```
+Visit `http://localhost:4000/login` to authenticate with Spotify then browse playlists or search for tracks. Favorites can be managed at `/favorites`.
+
+## Docker
+A `Dockerfile` and `docker-compose.yml` are provided for local development.
+To build and run directly with Docker:
+```bash
+docker build -t smart-music-go .
+docker run --env-file .env -p 4000:4000 smart-music-go
+```
+To start with Docker Compose (persists the SQLite database to `./data`):
+```bash
+docker compose up --build
+```


### PR DESCRIPTION
## Summary
- document how to run the project locally and configure authentication
- document production deployment via Docker and Terraform
- add contributing guidelines
- link new docs from README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6844a9aa0e708321bdcd89d2364030a7