### PR TITLE
Add build deps in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Simple multi-stage build for Smart-Music-Go
 FROM golang:1.23-alpine AS builder
 WORKDIR /src
+RUN apk add --no-cache build-base sqlite-dev
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .


### PR DESCRIPTION
## Summary
- install build tools for SQLite

## Testing
- `docker build .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68459cd101e483219bf3964685bd1a51