### PR TITLE
Return error from NewSpotifyClient

### DIFF
--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -30,7 +30,10 @@ func main() {
 	}
 
 	// Initialize a Spotify client and application with dependencies
-	sc := spotify.NewSpotifyClient(clientID, clientSecret)
+	sc, err := spotify.NewSpotifyClient(clientID, clientSecret)
+	if err != nil {
+		log.Fatalf("spotify client init: %v", err)
+	}
 	auth := libspotify.NewAuthenticator(redirectURL, libspotify.ScopePlaylistReadPrivate)
 	auth.SetAuthInfo(clientID, clientSecret)
 	dbPath := os.Getenv("DATABASE_PATH")

--- a/pkg/spotify/spotify.go
+++ b/pkg/spotify/spotify.go
@@ -28,7 +28,7 @@ type TrackSearcher interface {
 var _ TrackSearcher = (*SpotifyClient)(nil)
 
 // NewSpotifyClient creates a new Spotify API client with client credentials
-func NewSpotifyClient(clientID string, clientSecret string) *SpotifyClient {
+func NewSpotifyClient(clientID string, clientSecret string) (*SpotifyClient, error) {
 	config := &clientcredentials.Config{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
@@ -37,11 +37,11 @@ func NewSpotifyClient(clientID string, clientSecret string) *SpotifyClient {
 
 	token, err := config.Token(context.Background())
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	c := spotify.Authenticator{}.NewClient(token)
-	return &SpotifyClient{client: &c}
+	return &SpotifyClient{client: &c}, nil
 }
 
 // SearchTrack searches for a track on Spotify.


### PR DESCRIPTION
## Summary
- return an error from `NewSpotifyClient`
- handle client initialization errors in the web server

## Testing
- `go test ./...`