### PR TITLE
Mark Terraform secrets as sensitive

### DIFF
--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -1,0 +1,6 @@
+# AWS Terraform Example
+
+This directory contains Terraform configuration for deploying Smart-Music-Go to AWS.
+The variables `spotify_client_id`, `spotify_client_secret` and `spotify_redirect_url` hold
+Spotify credentials and are marked as `sensitive` in `variables.tf`. Provide these values
+using `terraform.tfvars` or `-var` command line flags and avoid committing them to version control.

--- a/deploy/aws/variables.tf
+++ b/deploy/aws/variables.tf
@@ -36,14 +36,17 @@ variable "image" {
 variable "spotify_client_id" {
   description = "Spotify client ID"
   type        = string
+  sensitive   = true
 }
 
 variable "spotify_client_secret" {
   description = "Spotify client secret"
   type        = string
+  sensitive   = true
 }
 
 variable "spotify_redirect_url" {
   description = "OAuth redirect URL"
   type        = string
+  sensitive   = true
 }


### PR DESCRIPTION
## Summary
- mark spotify variables as sensitive in Terraform
- add an AWS README calling out sensitive variables

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68459fd06adc8321890e77d1d311ad08