### PR TITLE
Switch project to Go 1.22

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Thank you for considering contributing to Smart-Music-Go! The following guidelines help keep the project consistent and easy to work with.
 
 ## Development Setup
-1. Install Go 1.23 or later and clone the repository.
+1. Install Go 1.22 or later and clone the repository.
 2. Copy `.env.example` to `.env` and provide your Spotify credentials as described in [docs/usage.md](docs/usage.md).
 3. Build the frontend assets under `ui/frontend` with `npm install && npm run build`.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Simple multi-stage build for Smart-Music-Go
-FROM golang:1.23-alpine AS builder
+FROM golang:1.22-alpine AS builder
 WORKDIR /src
 RUN apk add --no-cache build-base sqlite-dev
 COPY go.mod go.sum ./

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The application allows users to search for music tracks. When a user enters a tr
 This section walks through setting up the application for local development.
 
 ## Prerequisites
-- Go 1.23 or later
+- Go 1.22 or later
 - go install github.com/zmb3/spotify@latest
 
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -3,7 +3,7 @@
 This guide covers running Smart-Music-Go locally and configuring Spotify authentication.
 
 ## Prerequisites
-- Go 1.23 or later
+- Go 1.22 or later
 - `go install github.com/zmb3/spotify@latest`
 - Node.js and npm for building the React frontend
 

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module Smart-Music-Go
 
-go 1.23.8
+go 1.22
 
 require (
 	github.com/mattn/go-sqlite3 v1.14.28
 	github.com/zmb3/spotify v1.3.0
-	golang.org/x/oauth2 v0.30.0
+	golang.org/x/oauth2 v0.26.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/mattn/go-sqlite3 v1.14.28 h1:ThEiQrnbtumT+QMknw63Befp/ce/nUPgBPMlRFEum7A=
 github.com/mattn/go-sqlite3 v1.14.28/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -14,8 +16,8 @@ github.com/zmb3/spotify v1.3.0/go.mod h1:GD7AAEMUJVYc2Z7p2a2S0E3/5f/KxM/vOnErNr4
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
-golang.org/x/oauth2 v0.30.0 h1:dnDm7JmhM45NNpd8FDDeLhK6FwqbOf4MLCM9zb1BOHI=
-golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=
+golang.org/x/oauth2 v0.26.0 h1:afQXWNNaeC4nvZ0Ed9XvCCzXM6UHJG7iCg0W4fPqSBE=
+golang.org/x/oauth2 v0.26.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=


### PR DESCRIPTION
## Summary
- switch module version to Go 1.22 and downgrade oauth2
- use `golang:1.22-alpine` for the Docker build
- update docs to reference Go 1.22

## Testing
- `go mod tidy`
- `go test ./...`