### PR TITLE
Build frontend in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,23 @@
 # Simple multi-stage build for Smart-Music-Go
 FROM golang:1.22-alpine AS builder
 WORKDIR /src
-RUN apk add --no-cache build-base sqlite-dev
+# Install build tools and Node for the frontend build
+RUN apk add --no-cache build-base sqlite-dev nodejs npm
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
+# Build the React frontend
+RUN cd ui/frontend && npm install && npm run build
+# Build the Go binary
 RUN go build -o smart-music-go cmd/web/main.go
 
 FROM alpine:latest
 WORKDIR /app
 COPY --from=builder /src/smart-music-go ./
-COPY ui ./ui
+# Copy templates and static assets
+COPY --from=builder /src/ui/templates ./ui/templates
+COPY --from=builder /src/ui/static ./ui/static
+# Copy the built frontend
+COPY --from=builder /src/ui/frontend/dist ./ui/frontend/dist
 EXPOSE 4000
 CMD ["./smart-music-go"]

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ After logging in you can mark tracks as favorites from the search results. View 
 ### Frontend Setup
 
 The React frontend lives under `ui/frontend` and is served from `/app/`.
-Build the production assets before running the Go server:
+Build the production assets before running the Go server (the Docker image
+builds these automatically):
 
 ```bash
 cd ui/frontend
@@ -74,7 +75,8 @@ After building, start the server as shown above and visit
 `http://localhost:4000/app/` to use the React interface.
 
 ### Docker
-A `Dockerfile` is included for local development. Build and run the container with:
+A `Dockerfile` is included for local development. Building the image also compiles
+the React frontend, so no manual npm build is required. Build and run the container with:
 
 ```bash
 docker build -t smart-music-go .

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -27,7 +27,9 @@ cd ui/frontend
 npm install
 npm run build
 ```
-The built assets will be served from `/app/` when the Go server runs.
+The built assets will be served from `/app/` when the Go server runs. When using
+Docker or Docker Compose this build step is handled automatically during the
+image build.
 
 ## Running the Server
 Start the application with:
@@ -38,7 +40,9 @@ Visit `http://localhost:4000/login` to authenticate with Spotify then browse pla
 JSON responses are served from `/api/search`, `/api/playlists` and `/api/favorites` for use by the React frontend.
 
 ## Docker
-A `Dockerfile` and `docker-compose.yml` are provided for local development.
+A `Dockerfile` and `docker-compose.yml` are provided for local development. The
+image build automatically compiles the React frontend so no manual npm build is
+needed.
 To build and run directly with Docker:
 ```bash
 docker build -t smart-music-go .


### PR DESCRIPTION
## Summary
- install Node.js and build the React frontend during the builder stage
- copy only the built frontend along with static assets in the final stage
- document that Docker builds the frontend automatically

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6846ee3fee3c8321ae4f21d6e35d5a58