### PR TITLE
Add recommendations endpoint and React view

### DIFF
--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -75,6 +75,8 @@ func main() {
 	mux.HandleFunc("/", app.Home)
 	mux.HandleFunc("/search", app.Search)
 	mux.HandleFunc("/api/search", app.SearchJSON)
+	mux.HandleFunc("/recommendations", app.Recommendations)
+	mux.HandleFunc("/api/recommendations", app.RecommendationsJSON)
 	mux.HandleFunc("/login", app.Login)
 	mux.HandleFunc("/callback", app.OAuthCallback)
 	mux.HandleFunc("/playlists", app.Playlists)

--- a/cmd/web/main_test.go
+++ b/cmd/web/main_test.go
@@ -24,6 +24,10 @@ func (f fakeSearcher) SearchTrack(track string) ([]libspotify.FullTrack, error) 
 	return f.tracks, f.err
 }
 
+func (f fakeSearcher) GetRecommendations(seeds libspotify.Seeds) ([]libspotify.FullTrack, error) {
+	return f.tracks, f.err
+}
+
 // TestMain changes the working directory so templates resolve correctly when
 // tests are run from the package directory.
 func TestMain(m *testing.M) {
@@ -44,6 +48,7 @@ func newServer() *httptest.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", app.Home)
 	mux.HandleFunc("/search", app.Search)
+	mux.HandleFunc("/recommendations", app.Recommendations)
 	mux.HandleFunc("/login", app.Login)
 	mux.HandleFunc("/callback", app.OAuthCallback)
 	mux.HandleFunc("/playlists", app.Playlists)

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -33,6 +33,10 @@ func (f fakeSearcher) SearchTrack(track string) ([]libspotify.FullTrack, error) 
 	return f.tracks, f.err
 }
 
+func (f fakeSearcher) GetRecommendations(seeds libspotify.Seeds) ([]libspotify.FullTrack, error) {
+	return f.tracks, f.err
+}
+
 func TestMain(m *testing.M) {
 	// change working directory to project root so template paths resolve
 	os.Chdir("../..")

--- a/pkg/spotify/spotify_test.go
+++ b/pkg/spotify/spotify_test.go
@@ -14,6 +14,10 @@ type fakeSearcher struct {
 	err       error
 }
 
+func (f *fakeSearcher) GetRecommendations(seeds libspotify.Seeds, attrs *libspotify.TrackAttributes, opt *libspotify.Options) (*libspotify.Recommendations, error) {
+	return nil, nil
+}
+
 func (f *fakeSearcher) Search(query string, t libspotify.SearchType) (*libspotify.SearchResult, error) {
 	f.lastQuery = query
 	f.lastType = t

--- a/ui/frontend/src/App.jsx
+++ b/ui/frontend/src/App.jsx
@@ -1,27 +1,39 @@
 // App is the root component for the React UI. It switches between the
 // search, playlists and favorites views.
-import { useState } from 'react'
-import Search from './Search.jsx'
-import Playlists from './Playlists.jsx'
-import Favorites from './Favorites.jsx'
-import './App.css'
+import { useState } from "react";
+import Search from "./Search.jsx";
+import Playlists from "./Playlists.jsx";
+import Favorites from "./Favorites.jsx";
+import Recommendations from "./Recommendations.jsx";
+import "./App.css";
 
 function App() {
   // Track which section of the app is currently visible.
-  const [view, setView] = useState('search')
+  const [view, setView] = useState("search");
 
   return (
     <div className="App">
       <h1>Smart Music Go</h1>
       <nav>
-        <button onClick={() => setView('search')}>Search</button>
-        <button onClick={() => setView('playlists')}>Playlists</button>
-        <button onClick={() => setView('favorites')}>Favorites</button>
+        <button onClick={() => setView("search")}>Search</button>
+        <button onClick={() => setView("recommendations")}>
+          Recommendations
+        </button>
+        <button onClick={() => setView("playlists")}>Playlists</button>
+        <button onClick={() => setView("favorites")}>Favorites</button>
       </nav>
       {/* Conditionally render the selected view component */}
-      {view === 'search' ? <Search /> : view === 'playlists' ? <Playlists /> : <Favorites />}
+      {view === "search" ? (
+        <Search />
+      ) : view === "recommendations" ? (
+        <Recommendations />
+      ) : view === "playlists" ? (
+        <Playlists />
+      ) : (
+        <Favorites />
+      )}
     </div>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/ui/frontend/src/Recommendations.jsx
+++ b/ui/frontend/src/Recommendations.jsx
@@ -1,0 +1,54 @@
+// Recommendations retrieves track suggestions based on a seed track ID.
+import { useState } from "react";
+
+function Recommendations() {
+  const [trackID, setTrackID] = useState("");
+  const [results, setResults] = useState([]);
+  const [error, setError] = useState("");
+
+  const fetchRecs = async () => {
+    if (!trackID) return;
+    try {
+      const res = await fetch(
+        `/api/recommendations?track_id=${encodeURIComponent(trackID)}`,
+      );
+      if (!res.ok) {
+        setError("Failed to load recommendations");
+        setResults([]);
+        return;
+      }
+      const data = await res.json();
+      setResults(data);
+      setError("");
+    } catch {
+      setError("Failed to load recommendations");
+      setResults([]);
+    }
+  };
+
+  return (
+    <div>
+      <h2>Recommendations</h2>
+      <input
+        value={trackID}
+        onChange={(e) => setTrackID(e.target.value)}
+        placeholder="Enter a track ID"
+      />
+      <button onClick={fetchRecs}>Get Recommendations</button>
+      {error && <p>{error}</p>}
+      <div className="results">
+        {results.map((t) => (
+          <div className="track" key={t.ID}>
+            {t.Album?.Images?.length > 0 && (
+              <img src={t.Album.Images[0].URL} alt="Album art" />
+            )}
+            <p className="name">{t.Name}</p>
+            <p className="artist">{t.Artists[0]?.Name}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default Recommendations;

--- a/ui/templates/recommendations.html
+++ b/ui/templates/recommendations.html
@@ -1,0 +1,9 @@
+<!-- Template listing recommended tracks based on a seed track -->
+<h1>Recommendations</h1>
+<ul>
+{{range .}}
+  <li>{{.Name}} - {{(index .Artists 0).Name}}</li>
+{{else}}
+  <li>No recommendations found</li>
+{{end}}
+</ul>


### PR DESCRIPTION
## Summary
- support Spotify recommendations in spotify package
- add Recommendations and RecommendationsJSON handlers
- register new routes in main
- expose recommendations in React frontend

## Testing
- `go test ./...`