### PR TITLE
Add multi-service search and mood playlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ DATABASE_PATH=smartmusic.db
 ```
 The database schema is created automatically on startup, so no manual migrations are required.
 
+`MUSIC_SERVICE` selects the backend provider. Set to `spotify` (default) or
+`youtube`. When using the YouTube provider you must also set `YOUTUBE_API_KEY`.
+
 You can copy the provided `.env.example` to `.env` and populate your values:
 
 ```

--- a/cmd/web/main_test.go
+++ b/cmd/web/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"Smart-Music-Go/pkg/db"
 	"Smart-Music-Go/pkg/handlers"
+	"Smart-Music-Go/pkg/music"
 	libspotify "github.com/zmb3/spotify"
 	"io"
 	"net/http"
@@ -16,15 +17,15 @@ import (
 // pre-defined results and errors so handlers can be tested without hitting the
 // real Spotify API.
 type fakeSearcher struct {
-	tracks []libspotify.FullTrack
+	tracks []music.Track
 	err    error
 }
 
-func (f fakeSearcher) SearchTrack(track string) ([]libspotify.FullTrack, error) {
+func (f fakeSearcher) SearchTrack(track string) ([]music.Track, error) {
 	return f.tracks, f.err
 }
 
-func (f fakeSearcher) GetRecommendations(seeds libspotify.Seeds) ([]libspotify.FullTrack, error) {
+func (f fakeSearcher) GetRecommendations(seedIDs []string) ([]music.Track, error) {
 	return f.tracks, f.err
 }
 
@@ -38,13 +39,13 @@ func TestMain(m *testing.M) {
 // newServer creates an HTTP server with all routes registered using in-memory
 // dependencies so the endpoints can be exercised in tests.
 func newServer() *httptest.Server {
-	fs := fakeSearcher{tracks: []libspotify.FullTrack{
+	fs := fakeSearcher{tracks: []music.Track{
 		{SimpleTrack: libspotify.SimpleTrack{Name: "Song", Artists: []libspotify.SimpleArtist{{Name: "Artist"}}, ExternalURLs: map[string]string{"spotify": "http://example.com"}}},
 	}}
 	auth := libspotify.NewAuthenticator("http://example.com/callback")
 	auth.SetAuthInfo("id", "secret")
 	database, _ := db.New(":memory:")
-	app := &handlers.Application{Spotify: fs, Authenticator: auth, DB: database}
+	app := &handlers.Application{Music: fs, Authenticator: auth, DB: database}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", app.Home)
 	mux.HandleFunc("/search", app.Search)

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"os"
 	"testing"
+	"time"
 
 	"golang.org/x/oauth2"
 )
@@ -52,5 +53,28 @@ func TestSaveAndGetToken(t *testing.T) {
 	}
 	if got.RefreshToken != tok.RefreshToken {
 		t.Fatalf("expected refresh %s got %s", tok.RefreshToken, got.RefreshToken)
+	}
+}
+
+// TestHistory verifies that listening events can be stored and summarized.
+func TestHistory(t *testing.T) {
+	d, err := New(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	now := time.Now()
+	if err := d.AddHistory("u", "1", "Artist", now); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.AddHistory("u", "2", "Artist", now.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	artists, err := d.TopArtistsSince("u", now.Add(-time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(artists) != 1 || artists[0].Artist != "Artist" || artists[0].Count != 2 {
+		t.Fatalf("unexpected summary: %+v", artists)
 	}
 }

--- a/pkg/music/service.go
+++ b/pkg/music/service.go
@@ -1,0 +1,25 @@
+// Package music defines generic interfaces and data structures for
+// interacting with music providers. Implementations can wrap Spotify,
+// YouTube or any other service. By depending on this package the rest of
+// the application can remain agnostic about the underlying platform.
+//
+// Track is currently an alias of spotify.FullTrack so handlers and
+// templates operate on familiar fields (Name, Album, Artists etc). Other
+// services should populate these fields where possible.
+package music
+
+import libspotify "github.com/zmb3/spotify"
+
+// Track represents a track returned by a music service. For compatibility
+// with the existing templates it mirrors spotify.FullTrack.
+type Track = libspotify.FullTrack
+
+// Service exposes searching and recommendation capabilities. Additional
+// features can be implemented by concrete services.
+type Service interface {
+	// SearchTrack returns tracks matching the query string. An error is
+	// returned when the service encounters a failure or no tracks are found.
+	SearchTrack(query string) ([]Track, error)
+	// GetRecommendations returns tracks related to the provided seed IDs.
+	GetRecommendations(seedIDs []string) ([]Track, error)
+}

--- a/pkg/spotify/spotify_test.go
+++ b/pkg/spotify/spotify_test.go
@@ -14,6 +14,10 @@ type fakeSearcher struct {
 	err       error
 }
 
+func (f *fakeSearcher) GetAudioFeatures(ids ...libspotify.ID) ([]*libspotify.AudioFeatures, error) {
+	return nil, nil
+}
+
 func (f *fakeSearcher) GetRecommendations(seeds libspotify.Seeds, attrs *libspotify.TrackAttributes, opt *libspotify.Options) (*libspotify.Recommendations, error) {
 	return nil, nil
 }

--- a/pkg/youtube/youtube.go
+++ b/pkg/youtube/youtube.go
@@ -1,0 +1,138 @@
+// Package youtube implements the music.Service interface using the
+// YouTube Data API. Only the endpoints required by the application are
+// supported. An API key must be provided when constructing the client.
+//
+// Network calls are performed using the provided http.Client allowing
+// callers to substitute a test client.
+package youtube
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	libspotify "github.com/zmb3/spotify"
+
+	"Smart-Music-Go/pkg/music"
+)
+
+// Client provides access to the YouTube Data API.
+type Client struct {
+	Key    string
+	Client *http.Client
+}
+
+// ensure Client implements the music.Service interface.
+var _ music.Service = (*Client)(nil)
+
+// SearchTrack queries the YouTube search API and converts results into
+// music.Track values. Only the first page of results is returned.
+func (c *Client) SearchTrack(q string) ([]music.Track, error) {
+	if c.Client == nil {
+		c.Client = http.DefaultClient
+	}
+	u := "https://www.googleapis.com/youtube/v3/search"
+	params := url.Values{
+		"part":       {"snippet"},
+		"type":       {"video"},
+		"maxResults": {"5"},
+		"q":          {q},
+		"key":        {c.Key},
+	}
+	resp, err := c.Client.Get(u + "?" + params.Encode())
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("youtube search error: %s", resp.Status)
+	}
+	var body struct {
+		Items []struct {
+			ID struct {
+				VideoID string `json:"videoId"`
+			} `json:"id"`
+			Snippet struct {
+				Title        string `json:"title"`
+				ChannelTitle string `json:"channelTitle"`
+				Thumbnails   struct {
+					Default struct{ URL string }
+				}
+			} `json:"snippet"`
+		} `json:"items"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, err
+	}
+	if len(body.Items) == 0 {
+		return nil, fmt.Errorf("no tracks found")
+	}
+	tracks := make([]music.Track, len(body.Items))
+	for i, item := range body.Items {
+		tracks[i] = libspotify.FullTrack{
+			SimpleTrack: libspotify.SimpleTrack{
+				ID:           libspotify.ID(item.ID.VideoID),
+				Name:         item.Snippet.Title,
+				Artists:      []libspotify.SimpleArtist{{Name: item.Snippet.ChannelTitle}},
+				ExternalURLs: map[string]string{"youtube": "https://youtu.be/" + item.ID.VideoID},
+			},
+		}
+	}
+	return tracks, nil
+}
+
+// GetRecommendations fetches related videos for the given seed video ID.
+func (c *Client) GetRecommendations(seeds []string) ([]music.Track, error) {
+	if len(seeds) == 0 {
+		return nil, fmt.Errorf("no seed ids provided")
+	}
+	if c.Client == nil {
+		c.Client = http.DefaultClient
+	}
+	seed := seeds[0]
+	u := "https://www.googleapis.com/youtube/v3/search"
+	params := url.Values{
+		"part":             {"snippet"},
+		"type":             {"video"},
+		"relatedToVideoId": {seed},
+		"maxResults":       {"5"},
+		"key":              {c.Key},
+	}
+	resp, err := c.Client.Get(u + "?" + params.Encode())
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("youtube recommendation error: %s", resp.Status)
+	}
+	var body struct {
+		Items []struct {
+			ID      struct{ VideoID string } `json:"id"`
+			Snippet struct {
+				Title        string `json:"title"`
+				ChannelTitle string `json:"channelTitle"`
+				Thumbnails   struct{ Default struct{ URL string } }
+			} `json:"snippet"`
+		} `json:"items"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, err
+	}
+	if len(body.Items) == 0 {
+		return nil, fmt.Errorf("no recommendations found")
+	}
+	tracks := make([]music.Track, len(body.Items))
+	for i, item := range body.Items {
+		tracks[i] = libspotify.FullTrack{
+			SimpleTrack: libspotify.SimpleTrack{
+				ID:           libspotify.ID(item.ID.VideoID),
+				Name:         item.Snippet.Title,
+				Artists:      []libspotify.SimpleArtist{{Name: item.Snippet.ChannelTitle}},
+				ExternalURLs: map[string]string{"youtube": "https://youtu.be/" + item.ID.VideoID},
+			},
+		}
+	}
+	return tracks, nil
+}

--- a/ui/frontend/src/App.jsx
+++ b/ui/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import Search from "./Search.jsx";
 import Playlists from "./Playlists.jsx";
 import Favorites from "./Favorites.jsx";
 import Recommendations from "./Recommendations.jsx";
+import Mood from "./Mood.jsx";
 import "./App.css";
 
 function App() {
@@ -24,6 +25,7 @@ function App() {
         <button onClick={() => setView("recommendations")}>
           Recommendations
         </button>
+        <button onClick={() => setView("mood")}>Mood</button>
         <button onClick={() => setView("playlists")}>Playlists</button>
         <button onClick={() => setView("favorites")}>Favorites</button>
         <button onClick={toggleTheme}>Toggle Theme</button>
@@ -33,6 +35,8 @@ function App() {
         <Search theme={theme} />
       ) : view === "recommendations" ? (
         <Recommendations />
+      ) : view === "mood" ? (
+        <Mood />
       ) : view === "playlists" ? (
         <Playlists />
       ) : (

--- a/ui/frontend/src/Mood.jsx
+++ b/ui/frontend/src/Mood.jsx
@@ -1,0 +1,56 @@
+// Mood allows users to request recommendations based on tempo.
+// It sends the track ID and optional tempo range to the server
+// which uses Spotify audio features to build the playlist.
+import { useState } from "react";
+
+function Mood() {
+  const [trackID, setTrackID] = useState("");
+  const [results, setResults] = useState([]);
+  const [error, setError] = useState("");
+
+  const fetchMood = async () => {
+    if (!trackID) return;
+    try {
+      const res = await fetch(
+        `/api/recommendations/mood?track_id=${encodeURIComponent(trackID)}`,
+      );
+      if (!res.ok) {
+        setError("Failed to load recommendations");
+        setResults([]);
+        return;
+      }
+      const data = await res.json();
+      setResults(data);
+      setError("");
+    } catch {
+      setError("Failed to load recommendations");
+      setResults([]);
+    }
+  };
+
+  return (
+    <div>
+      <h2>Mood Playlist</h2>
+      <input
+        value={trackID}
+        onChange={(e) => setTrackID(e.target.value)}
+        placeholder="Track ID"
+      />
+      <button onClick={fetchMood}>Generate</button>
+      {error && <p>{error}</p>}
+      <div className="results">
+        {results.map((t) => (
+          <div className="track" key={t.ID}>
+            {t.Album?.Images?.length > 0 && (
+              <img src={t.Album.Images[0].URL} alt="Album art" />
+            )}
+            <p className="name">{t.Name}</p>
+            <p className="artist">{t.Artists[0]?.Name}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default Mood;


### PR DESCRIPTION
## Summary
- implement generic music service interface
- add YouTube search service
- enhance Spotify client with audio feature helpers
- enable service selection via `MUSIC_SERVICE`
- add mood-based recommendation endpoint
- track listening history and provide insights
- extend React UI with mood playlist page
- update docs and tests for new features

## Testing
- `go test ./...`