### PR TITLE
Improve tests and docs, refactor handlers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.22'
+      - name: Cache Go
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-
+      - name: Go fmt and test
+        run: |
+          gofmt -w $(git ls-files '*.go')
+          go test ./...
+      - name: Frontend dependencies
+        run: |
+          cd ui/frontend && npm install && npm run build && npx playwright install --with-deps
+      - name: Playwright tests
+        run: cd ui/frontend && npx playwright test
+        env:
+          CI: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ Thank you for considering contributing to Smart-Music-Go! The following guidelin
   go test ./...
   ```
 - For frontend changes run `npm run build` so that `ui/frontend/dist` is updated.
+- Continuous integration runs the same checks in `.github/workflows/ci.yml` when you open a pull request.
 
 ## Pull Requests
 1. Create a feature branch for your change.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Additional endpoints provide listening insights and collaborative playlist featu
 ```
 curl http://localhost:4000/api/insights/monthly
 curl -X POST http://localhost:4000/api/collections
+curl http://localhost:4000/api/recommendations/mood?track_id=123
+curl "http://localhost:4000/api/recommendations/advanced?track_id=123&min_energy=0.5"
 ```
 
 
@@ -155,7 +157,6 @@ Smart-Music-Go aims to evolve beyond a basic Spotify interface. Planned improvem
 - **Listening insights** now provide top artists and top tracks over a chosen period.
 - **Monthly summaries** group your listening history by month for trend analysis.
 - **Collaborative playlists** APIs allow creating collections that multiple users can populate.
-- **Collaborative playlists** so users can share favorites and create collections together.
 - **Personal listening insights** stored in SQLite to highlight trends and weekly discoveries.
 - **Enhanced UI/UX** with theme switching and audio previews in the React frontend.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -39,6 +39,8 @@ go run cmd/web/main.go
 Visit `http://localhost:4000/login` to authenticate with Spotify then browse playlists or search for tracks. Favorites can be managed at `/favorites`.
 JSON responses are served from `/api/search`, `/api/playlists` and `/api/favorites` for use by the React frontend.
 For monthly summaries of your listening history call `/api/insights/monthly`. Collaborative playlists can be created via `/api/collections` and managed using the `/api/collections/{id}/tracks` and `/api/collections/{id}/users` endpoints.
+Mood based recommendations are available via `/api/recommendations/mood?track_id=<id>` when a Spotify client is configured. Advanced filtering of energy and valence can be accessed through `/api/recommendations/advanced` with query parameters like `min_energy`.
+To search across Spotify, YouTube and SoundCloud simultaneously set `MUSIC_SERVICE=aggregate` in your environment and provide the respective API keys.
 
 ## Docker
 A `Dockerfile` and `docker-compose.yml` are provided for local development. The
@@ -53,3 +55,11 @@ To start with Docker Compose (persists the SQLite database to `./data`):
 ```bash
 docker compose up --build
 ```
+
+## Frontend Tests
+The React application is tested using Playwright. From `ui/frontend` run:
+```bash
+npm install
+npx playwright test
+```
+The tests assume the development server is running on port 4173 via `npm run preview` as configured in `playwright.config.cjs`.

--- a/pkg/handlers/auth.go
+++ b/pkg/handlers/auth.go
@@ -1,0 +1,141 @@
+// Package handlers contains HTTP handlers for Smart-Music-Go. This file groups
+// authentication related helpers and endpoints such as the OAuth login and
+// callback handlers. Keeping these routines separate from the main handlers
+// file improves readability and maintainability.
+
+package handlers
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"golang.org/x/oauth2"
+)
+
+// signValue computes an HMAC signature for value and appends it using the
+// format value|signature. The signature is base64 URL encoded so it can be
+// safely stored in cookies.
+func signValue(value string, key []byte) string {
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte(value))
+	sig := mac.Sum(nil)
+	return value + "|" + base64.RawURLEncoding.EncodeToString(sig)
+}
+
+// verifyValue checks the HMAC signature appended to signed. It returns the
+// original value and true when the signature matches the provided key.
+func verifyValue(signed string, key []byte) (string, bool) {
+	parts := strings.Split(signed, "|")
+	if len(parts) != 2 {
+		return "", false
+	}
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte(parts[0]))
+	expected := mac.Sum(nil)
+	sig, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil || !hmac.Equal(expected, sig) {
+		return "", false
+	}
+	return parts[0], true
+}
+
+// decodeToken converts the base64 encoded JSON token stored in cookies back
+// into an oauth2.Token instance.
+func decodeToken(v string) (*oauth2.Token, error) {
+	data, err := base64.StdEncoding.DecodeString(v)
+	if err != nil {
+		return nil, err
+	}
+	var t oauth2.Token
+	if err := json.Unmarshal(data, &t); err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+// encodeToken signs and encodes the OAuth token for storage in a cookie.
+func (app *Application) encodeToken(t *oauth2.Token, secure bool) *http.Cookie {
+	b, _ := json.Marshal(t)
+	return &http.Cookie{
+		Name:     "spotify_token",
+		Value:    signValue(base64.StdEncoding.EncodeToString(b), app.SignKey),
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   secure,
+	}
+}
+
+// refreshIfExpired refreshes the OAuth token if it has expired using the
+// configured authenticator. The new token is persisted and written back to the
+// cookie.
+func (app *Application) refreshIfExpired(w http.ResponseWriter, r *http.Request, userID string, t *oauth2.Token) (*oauth2.Token, error) {
+	if t == nil || t.Valid() || t.RefreshToken == "" {
+		return t, nil
+	}
+	client := app.Authenticator.NewClient(t)
+	newTok, err := client.Token()
+	if err != nil {
+		return t, err
+	}
+	if app.DB != nil && userID != "" {
+		app.DB.SaveToken(userID, newTok)
+	}
+	http.SetCookie(w, app.encodeToken(newTok, r.TLS != nil))
+	return newTok, nil
+}
+
+// Login begins the Spotify OAuth flow and redirects the user to the
+// authorization URL with a signed state value stored in a cookie.
+func (app *Application) Login(w http.ResponseWriter, r *http.Request) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		http.Error(w, "failed to generate state", http.StatusInternalServerError)
+		return
+	}
+	state := base64.RawURLEncoding.EncodeToString(b)
+	http.SetCookie(w, &http.Cookie{
+		Name:     "oauth_state",
+		Value:    signValue(state, app.SignKey),
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   r.TLS != nil,
+	})
+	http.Redirect(w, r, app.Authenticator.AuthURL(state), http.StatusFound)
+}
+
+// OAuthCallback completes the OAuth flow by exchanging the authorization code
+// for a token. The resulting token and user ID are stored in signed cookies.
+func (app *Application) OAuthCallback(w http.ResponseWriter, r *http.Request) {
+	c, err := r.Cookie("oauth_state")
+	if err != nil {
+		http.Error(w, "state mismatch", http.StatusBadRequest)
+		return
+	}
+	state, ok := verifyValue(c.Value, app.SignKey)
+	if !ok || r.URL.Query().Get("state") != state {
+		http.Error(w, "state mismatch", http.StatusBadRequest)
+		return
+	}
+	http.SetCookie(w, &http.Cookie{Name: "oauth_state", Path: "/", MaxAge: -1})
+
+	token, err := app.Authenticator.Token(state, r)
+	if err != nil {
+		http.Error(w, "authentication failed", http.StatusInternalServerError)
+		return
+	}
+	client := app.Authenticator.NewClient(token)
+	user, err := client.CurrentUser()
+	if err == nil && app.DB != nil {
+		app.DB.SaveToken(user.ID, token)
+	}
+	http.SetCookie(w, app.encodeToken(token, r.TLS != nil))
+	if user != nil {
+		http.SetCookie(w, &http.Cookie{Name: "spotify_user_id", Value: signValue(user.ID, app.SignKey), Path: "/"})
+	}
+	http.Redirect(w, r, "/", http.StatusFound)
+}

--- a/pkg/handlers/favorites.go
+++ b/pkg/handlers/favorites.go
@@ -1,0 +1,107 @@
+// Package handlers groups HTTP handlers for Smart-Music-Go. This file focuses
+// on endpoints that manage user favorites, both the HTML page and the JSON API.
+// Splitting favorites logic keeps the handler implementations concise.
+
+package handlers
+
+import (
+	"encoding/json"
+	"html/template"
+	"log"
+	"net/http"
+)
+
+// AddFavorite accepts a JSON payload describing a track and saves it to the
+// current user's favorites list. The user ID is retrieved from a signed cookie.
+func (app *Application) AddFavorite(w http.ResponseWriter, r *http.Request) {
+	userCookie, err := r.Cookie("spotify_user_id")
+	if err != nil {
+		http.Error(w, "authentication required", http.StatusUnauthorized)
+		return
+	}
+	if v, ok := verifyValue(userCookie.Value, app.SignKey); ok {
+		userCookie.Value = v
+	} else {
+		http.Error(w, "authentication required", http.StatusUnauthorized)
+		return
+	}
+	var req struct {
+		TrackID    string `json:"track_id"`
+		TrackName  string `json:"track_name"`
+		ArtistName string `json:"artist_name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if app.DB == nil {
+		http.Error(w, "db not configured", http.StatusInternalServerError)
+		return
+	}
+	if err := app.DB.AddFavorite(userCookie.Value, req.TrackID, req.TrackName, req.ArtistName); err != nil {
+		http.Error(w, "failed to save favorite", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+}
+
+// Favorites renders an HTML page listing tracks the user has marked as
+// favorites.
+func (app *Application) Favorites(w http.ResponseWriter, r *http.Request) {
+	userCookie, err := r.Cookie("spotify_user_id")
+	if err != nil {
+		http.Error(w, "authentication required", http.StatusUnauthorized)
+		return
+	}
+	if v, ok := verifyValue(userCookie.Value, app.SignKey); ok {
+		userCookie.Value = v
+	} else {
+		http.Error(w, "authentication required", http.StatusUnauthorized)
+		return
+	}
+	if app.DB == nil {
+		http.Error(w, "db not configured", http.StatusInternalServerError)
+		return
+	}
+	favs, err := app.DB.ListFavorites(userCookie.Value)
+	if err != nil {
+		http.Error(w, "failed to load favorites", http.StatusInternalServerError)
+		return
+	}
+	tmpl, err := template.ParseFiles("ui/templates/favorites.html")
+	if err != nil {
+		http.Error(w, "template error", http.StatusInternalServerError)
+		return
+	}
+	if err := tmpl.Execute(w, favs); err != nil {
+		log.Printf("favorites template execute: %v", err)
+		http.Error(w, "render error", http.StatusInternalServerError)
+	}
+}
+
+// FavoritesJSON returns the user's favorites as JSON for consumption by the
+// frontend.
+func (app *Application) FavoritesJSON(w http.ResponseWriter, r *http.Request) {
+	userCookie, err := r.Cookie("spotify_user_id")
+	if err != nil {
+		http.Error(w, "authentication required", http.StatusUnauthorized)
+		return
+	}
+	if v, ok := verifyValue(userCookie.Value, app.SignKey); ok {
+		userCookie.Value = v
+	} else {
+		http.Error(w, "authentication required", http.StatusUnauthorized)
+		return
+	}
+	if app.DB == nil {
+		http.Error(w, "db not configured", http.StatusInternalServerError)
+		return
+	}
+	favs, err := app.DB.ListFavorites(userCookie.Value)
+	if err != nil {
+		http.Error(w, "failed to load favorites", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(favs)
+}

--- a/pkg/handlers/insights.go
+++ b/pkg/handlers/insights.go
@@ -1,0 +1,104 @@
+// Package handlers provides HTTP handlers for Smart-Music-Go. This file contains
+// endpoints that expose listening insights such as top artists and tracks.
+
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// InsightsJSON returns the most played artists for the last week.
+func (app *Application) InsightsJSON(w http.ResponseWriter, r *http.Request) {
+	userCookie, err := r.Cookie("spotify_user_id")
+	if err != nil {
+		http.Error(w, "authentication required", http.StatusUnauthorized)
+		return
+	}
+	if v, ok := verifyValue(userCookie.Value, app.SignKey); ok {
+		userCookie.Value = v
+	} else {
+		http.Error(w, "authentication required", http.StatusUnauthorized)
+		return
+	}
+	if app.DB == nil {
+		http.Error(w, "db not configured", http.StatusInternalServerError)
+		return
+	}
+	since := time.Now().AddDate(0, 0, -7)
+	res, err := app.DB.TopArtistsSince(userCookie.Value, since)
+	if err != nil {
+		http.Error(w, "failed to load insights", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(res)
+}
+
+// InsightsTracksJSON returns the most played tracks for a configurable period
+// controlled by the 'days' query parameter.
+func (app *Application) InsightsTracksJSON(w http.ResponseWriter, r *http.Request) {
+	userCookie, err := r.Cookie("spotify_user_id")
+	if err != nil {
+		http.Error(w, "authentication required", http.StatusUnauthorized)
+		return
+	}
+	if v, ok := verifyValue(userCookie.Value, app.SignKey); ok {
+		userCookie.Value = v
+	} else {
+		http.Error(w, "authentication required", http.StatusUnauthorized)
+		return
+	}
+	if app.DB == nil {
+		http.Error(w, "db not configured", http.StatusInternalServerError)
+		return
+	}
+	days, _ := strconv.Atoi(r.URL.Query().Get("days"))
+	if days <= 0 {
+		days = 7
+	}
+	since := time.Now().AddDate(0, 0, -days)
+	res, err := app.DB.TopTracksSince(userCookie.Value, since)
+	if err != nil {
+		http.Error(w, "failed to load insights", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(res)
+}
+
+// InsightsMonthlyJSON groups play counts by month starting from an optional
+// 'since' query parameter (YYYY-MM-DD). If omitted a one year lookback is used.
+func (app *Application) InsightsMonthlyJSON(w http.ResponseWriter, r *http.Request) {
+	userCookie, err := r.Cookie("spotify_user_id")
+	if err != nil {
+		http.Error(w, "authentication required", http.StatusUnauthorized)
+		return
+	}
+	if v, ok := verifyValue(userCookie.Value, app.SignKey); ok {
+		userCookie.Value = v
+	} else {
+		http.Error(w, "authentication required", http.StatusUnauthorized)
+		return
+	}
+	if app.DB == nil {
+		http.Error(w, "db not configured", http.StatusInternalServerError)
+		return
+	}
+	sinceStr := r.URL.Query().Get("since")
+	since := time.Now().AddDate(-1, 0, 0)
+	if sinceStr != "" {
+		if t, err := time.Parse("2006-01-02", sinceStr); err == nil {
+			since = t
+		}
+	}
+	res, err := app.DB.MonthlyPlayCountsSince(userCookie.Value, since)
+	if err != nil {
+		http.Error(w, "failed to load insights", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(res)
+}

--- a/pkg/music/aggregate_test.go
+++ b/pkg/music/aggregate_test.go
@@ -18,6 +18,32 @@ func TestAggregatorMerge(t *testing.T) {
 	}
 }
 
+// TestAggregatorGetRecommendations verifies that GetRecommendations merges
+// results from multiple services and eliminates duplicate track IDs. Each fake
+// service returns overlapping recommendations to ensure the merge logic works
+// correctly.
+func TestAggregatorGetRecommendations(t *testing.T) {
+	svc1 := fakeService{tracks: []Track{newTrack("a"), newTrack("b")}}
+	svc2 := fakeService{tracks: []Track{newTrack("b"), newTrack("c")}}
+	agg := Aggregator{Services: []Service{svc1, svc2}}
+	res, err := agg.GetRecommendations(context.Background(), []string{"seed"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res) != 3 {
+		t.Fatalf("expected 3 unique tracks got %d", len(res))
+	}
+	got := map[string]bool{}
+	for _, t := range res {
+		got[string(t.ID)] = true
+	}
+	for _, id := range []string{"a", "b", "c"} {
+		if !got[id] {
+			t.Errorf("missing %s in results", id)
+		}
+	}
+}
+
 type fakeService struct{ tracks []Track }
 
 func (f fakeService) SearchTrack(context.Context, string) ([]Track, error) { return f.tracks, nil }

--- a/ui/frontend/tests/basic.spec.cjs
+++ b/ui/frontend/tests/basic.spec.cjs
@@ -4,3 +4,15 @@ test('loads homepage', async ({ page }) => {
   await page.goto('/');
   await expect(page.locator('h1')).toHaveText('Smart Music Go');
 });
+
+// This test simulates marking a track as a favorite from the UI. It navigates
+// to the app, performs a search using the mock API and clicks the Favorite
+// button. The track should then appear in the Favorites list.
+test('adds item to favorites', async ({ page }) => {
+  await page.goto('/app/');
+  await page.locator('input[name="query"]').fill('song');
+  await page.locator('button[type="submit"]').click();
+  await page.locator('button:has-text("Favorite")').first().click();
+  await page.click('text=Favorites');
+  await expect(page.locator('li')).toContainText('song');
+});


### PR DESCRIPTION
## Summary
- split large handlers file into smaller modules
- add CI workflow and frontend favorite test
- validate API keys at startup
- document advanced endpoints and testing
- expand unit tests for aggregator and insights

## Testing
- `go test ./...`
- `npm install`
- `npm run build`
- `npx playwright test` *(fails: missing browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68640d09c5348321a411689cc4df2227